### PR TITLE
Fix: the same file cannot be uploaded to different prefix or bucket

### DIFF
--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -127,7 +127,7 @@ function upload(options, { key, data: path, type }) {
     /// 每次断开将从上次的记录继续上传, 防止弱网环境下无法上传成功
     /// 如果存在则跳过上传. 弱网环境上传大文件会比较有用
     if (options[OPTIONS.Resume]) {
-      const hash = md5hash(path);
+      const hash = md5hash(`${bucket}${saveKey || key}`);
       const uploadedDir = getUploadedLogDir();
 
       if (fs.existsSync(`${uploadedDir}${hash}`)) {


### PR DESCRIPTION
Examples:
    
    - build
    - - a.js
    
    task 1.
    ```javascript
    qiniu-upload -r 1 -es 1000000 \
        --verbose -b b \
        -p "a" \
        --base ./build --ak ${QINIU_AK} --sk ${QINIU_SK} 'build/**'
    ```
    
    task 2.
    ```javascript
    qiniu-upload -r 1 -es 100000 \
        --verbose -b b \
        -p "b"
        --base ./build --ak ${QINIU_AK} --sk ${QINIU_SK} 'build/**
    ```
    
    task 2 result:
    ```
    skip uplaod file build/a.js
    ```
    
    curl http://b/a/a.js  // 200
    curl http://b/b/a.js  // 404 not found